### PR TITLE
Resolves issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Deploy a High Availability Galera database cluster using the [Linode Ansible Col
 ## Installation
 Create a virtual environment to isolate dependencies from other packages on your system.
 ```
-python3 -m venv env
+python3 -m virtualenv env
 source env/bin/activate
 ```
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,10 +1,14 @@
 # roles/common/tasks
 
 # common tasks for all linodes
+- name: force ipv4 with apt
+  copy:
+    content: 'Acquire::ForceIPv4 "true";'
+    dest: /etc/apt/apt.conf.d/99force-ipv4
+
 - name: apt update
   apt:
-    name: "*"
-    state: latest
+    update_cache: yes
 
 - name: apt upgrade
   apt:


### PR DESCRIPTION
Resolves issue #1 by using `virtualenv` (instead of `venv`) which ships with the `wheel` package, and fixed syntax error with the apt update task, which was the cause of the 404s. Also forced IPv4 transport for `apt`.