### PR TITLE
resolve warning messages and fix typo in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,5 +2,4 @@
 host_key_checking = False
 VAULT_PASSWORD_FILE = ./vault-pass
 enable_plugins = linode
-inventory_path = /etc/anisble/hosts
-
+inventory_path = /etc/ansible/hosts

--- a/group_vars/galera/vars
+++ b/group_vars/galera/vars
@@ -5,4 +5,4 @@ type:
 region: 
 image:
 group: 
-tags:
+linode_tags:

--- a/provision.yml
+++ b/provision.yml
@@ -20,7 +20,7 @@
       authorized_keys: '{{ ssh_keys }}'
       private_ip: true
       group: '{{ group }}'
-      tags: '{{ tags }}'
+      tags: '{{ linode_tags }}'
       state: present
     register: linode
     with_sequence: count='{{count}}'
@@ -73,7 +73,7 @@
       path: ./hosts
       marker: "# {mark} GALERA LINODES"
       block: |
-        [galera-servers]
+        [galera_servers]
         {{ galera_ip1 }}
         {{ galera_ip2 }}
         {{ galera_ip3 }}
@@ -81,7 +81,7 @@
   - name: update in-memory inventory
     add_host:
       name: '{{ item }}'
-      groups: galera-servers
+      groups: galera_servers
     with_items:
       - '{{ galera_ip1 }}'
       - '{{ galera_ip2 }}'

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -95,7 +95,7 @@
 - name: set galera1 hostname
   shell: hostnamectl set-hostname '{{ host1 }}'
   run_once: true
-  delegate_to: "{{groups['galera-servers'][0]}}"
+  delegate_to: "{{groups['galera_servers'][0]}}"
 
 - name: set facts for galera1
   set_fact:
@@ -103,20 +103,20 @@
     wsrep_node_address: '{{ priv_ip1 }}'
     wsrep_node_name: '{{ host1 }}'
   run_once: true
-  delegate_to: "{{groups['galera-servers'][0]}}"
+  delegate_to: "{{groups['galera_servers'][0]}}"
 
 - name: configure galera1 galera.cnf
   template:
     src: galera.cnf.j2
     dest: /etc/mysql/conf.d/galera.cnf
   run_once: true
-  delegate_to: "{{groups['galera-servers'][0]}}"
+  delegate_to: "{{groups['galera_servers'][0]}}"
 
 # set up galera2
 - name: set galera2 hostname
   shell: hostnamectl set-hostname '{{ host2 }}'
   run_once: true
-  delegate_to: "{{groups['galera-servers'][1]}}"
+  delegate_to: "{{groups['galera_servers'][1]}}"
 
 - name: set facts for galera2
   set_fact:
@@ -124,20 +124,20 @@
     wsrep_node_address: '{{ priv_ip2 }}'
     wsrep_node_name: '{{ host2 }}'
   run_once: true
-  delegate_to: "{{groups['galera-servers'][1]}}"
+  delegate_to: "{{groups['galera_servers'][1]}}"
 
 - name: configure galera2 galera.cnf
   template:
     src: galera.cnf.j2
     dest: /etc/mysql/conf.d/galera.cnf
   run_once: true
-  delegate_to: "{{groups['galera-servers'][1]}}"
+  delegate_to: "{{groups['galera_servers'][1]}}"
 
 # set up galera3
 - name: set galera3 hostname
   shell: hostnamectl set-hostname '{{ host3 }}'
   run_once: true
-  delegate_to: "{{groups['galera-servers'][2]}}"
+  delegate_to: "{{groups['galera_servers'][2]}}"
 
 - name: set facts for galera3
   set_fact:
@@ -145,14 +145,14 @@
     wsrep_node_address: '{{ priv_ip3 }}'
     wsrep_node_name: '{{ host3 }}'
   run_once: true
-  delegate_to: "{{groups['galera-servers'][2]}}"
+  delegate_to: "{{groups['galera_servers'][2]}}"
 
 - name: configure galera3 galera.cnf
   template:
     src: galera.cnf.j2
     dest: /etc/mysql/conf.d/galera.cnf
   run_once: true
-  delegate_to: "{{groups['galera-servers'][2]}}"
+  delegate_to: "{{groups['galera_servers'][2]}}"
 
 # bootstrap the cluster
 - name: stop mysql
@@ -163,21 +163,21 @@
 - name: bootstrap galera1
   shell: galera_new_cluster
   run_once: true
-  delegate_to: "{{groups['galera-servers'][0]}}"
+  delegate_to: "{{groups['galera_servers'][0]}}"
 
 - name: start galera2 mysql
   service:
     name: mysql
     state: started
   run_once: true
-  delegate_to: "{{groups['galera-servers'][1]}}"
+  delegate_to: "{{groups['galera_servers'][1]}}"
 
 - name: start galera3 mysql
   service:
     name: mysql
     state: started
   run_once: true
-  delegate_to: "{{ groups['galera-servers'][2] }}"
+  delegate_to: "{{ groups['galera_servers'][2] }}"
 
 # set up firewall
 - name: install firewalld

--- a/site.yml
+++ b/site.yml
@@ -2,7 +2,7 @@
 
 # cluster pre-check
 - name: pre-check
-  hosts: galera-servers
+  hosts: galera_servers
   user: root
   vars_files:
     - group_vars/galera/vars
@@ -22,7 +22,7 @@
 
 # linodes
 - name: configure galera linodes
-  hosts: galera-servers
+  hosts: galera_servers
   user: root
   vars_files:
     - group_vars/galera/vars


### PR DESCRIPTION
Removes warning messages about invalid characters and `tags` variable name. Also fixed typo in `ansible.cfg`.