### PR TITLE
add pymysql to requirements.txt and set python3 interpreter

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,4 @@ host_key_checking = False
 VAULT_PASSWORD_FILE = ./vault-pass
 enable_plugins = linode
 inventory_path = /etc/ansible/hosts
+interpreter_python = /usr/bin/python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 linode_api4
 ansible
 polling
+pymysql

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -23,6 +23,8 @@
     - htop
     - rsync
     - fail2ban
+    - python3-pip
+    - python3-mysqldb
     state: latest
 
 - name: fail2ban jail.local

--- a/roles/db/tasks/debian.yml
+++ b/roles/db/tasks/debian.yml
@@ -1,7 +1,0 @@
-# roles/db/tasks/debian.yml
-
-- name: install python-mysqldb
-  apt:
-    name: python-mysqldb
-    state: latest
-    install_recommends: yes

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -19,18 +19,6 @@
     state: latest
     install_recommends: yes
 
-- name: install python-mysql dependency for debian 10
-  import_tasks: debian.yml
-  when:
-  - ansible_distribution == 'Debian'
-  - ansible_distribution_version == '10'
-
-- name: install python-mysql dependency for ubuntu 20.04
-  import_tasks: ubuntu.yml
-  when:
-  - ansible_distribution == 'Ubuntu'
-  - ansible_distribution_version == '20.04'
-
 - name: create mariadb.service.d directory
   file:
     path: /etc/systemd/system/mariadb.service.d

--- a/roles/db/tasks/ubuntu.yml
+++ b/roles/db/tasks/ubuntu.yml
@@ -1,7 +1,0 @@
-# roles/db/tasks/ubuntu.yml
-
-- name: install python3-mysqldb
-  apt:
-    name: python3-mysqldb
-    state: latest
-    install_recommends: yes


### PR DESCRIPTION
Resolves python2 deprecation warnings and gives `community.mysql` module what it needs to db queries on both Debian 10 and Ubuntu 20.04 without having to import the separate sub-tasks.